### PR TITLE
Nulls

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -104,14 +104,15 @@ class ParquetFile(object):
         dtypes = {k: v for k, v in self.dtypes.items() if k in columns}
 
         # TODO: if categories vary from one rg to next, need to cope
-        return dd.from_delayed(tot, metadata=dtypes)
+        return dd.from_delayed(tot, meta=dtypes)
 
-    def read_row_group(self, rg, columns, categories, filters={}):
+    def read_row_group(self, rg, columns, categories, filters={},
+                       infile=None):
         """Filter syntax: [(column, op, val), ...],
         where op is [==, >, >=, <, <=, !=, in, not in]
         """
         out = {}
-        fn = self.fn
+        fn = infile or self.fn
 
         for column in rg.columns:
             name = ".".join(column.meta_data.path_in_schema)
@@ -122,7 +123,7 @@ class ParquetFile(object):
             if column.file_path is None:
                 # continue reading from the same base file
                 infile = self.f
-            else:
+            elif infile is None:
                 # relative file
                 ofname = sep_from_open(self.open).join(
                         [os.path.dirname(self.fn), column.file_path])

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import array
 import io

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -208,19 +208,60 @@ def test_write_with_dask(tempdir):
         assert (df[col] == data[col]).all()
 
 
-@pytest.mark.skip()
 def test_nulls_roundtrip(tempdir):
     fname = os.path.join(tempdir, 'temp.parq')
     data = pd.DataFrame({'o': np.random.choice(['hello', 'world', None],
                                                size=1000)})
     data['cat'] = data['o'].astype('category')
-    writer.write(fname, data)
+    writer.write(fname, data, has_nulls=['o', 'cat'])
 
     r = ParquetFile(fname)
     df = r.to_pandas()
     for col in r.columns:
         assert (df[col] == data[col])[~data[col].isnull()].all()
         assert (data[col].isnull() == df[col].isnull()).all()
+
+
+def test_make_definitions_with_nulls():
+    for _ in range(10):
+        out = np.empty(1000, dtype=np.int32)
+        o = encoding.Numpy32(out)
+        data = pd.Series(np.random.choice([True, None],
+                                          size=np.random.randint(1, 1000)))
+        out = writer.make_definitions(data)
+        i = encoding.Numpy8(np.frombuffer(out, dtype=np.uint8))
+        encoding.read_rle_bit_packed_hybrid(i, 1, length=None, o=o)
+        out = o.so_far()[:len(data)]
+        assert (out == ~data.isnull()).sum()
+
+
+def test_make_definitions_without_nulls():
+    for _ in range(100):
+        out = np.empty(10000, dtype=np.int32)
+        o = encoding.Numpy32(out)
+        data = pd.Series([True] * np.random.randint(1, 10000))
+        out = writer.make_definitions(data)
+
+        l = len(data) << 1
+        p = 1
+        while l > 127:
+            l >>= 7
+            p += 1
+        assert len(out) == 4 + p + 1  # "length", num_count, value
+
+        i = encoding.Numpy8(np.frombuffer(out, dtype=np.uint8))
+        encoding.read_rle_bit_packed_hybrid(i, 1, length=None, o=o)
+        out = o.so_far()
+        assert (out == ~data.isnull()).sum()
+
+    # class mock:
+    #     def is_required(self, *args):
+    #         return False
+    #     def max_definition_level(self, *args):
+    #         return 1
+    #     def __getattr__(self, item):
+    #         return None
+    # halper, metadata = mock(), mock()
 
 
 @pytest.mark.skip()

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -228,8 +228,8 @@ def test_make_definitions_with_nulls():
         o = encoding.Numpy32(out)
         data = pd.Series(np.random.choice([True, None],
                                           size=np.random.randint(1, 1000)))
-        out = writer.make_definitions(data)
-        i = encoding.Numpy8(np.frombuffer(out, dtype=np.uint8))
+        out, d2 = writer.make_definitions(data)
+        i = encoding.Numpy8(np.fromstring(out, dtype=np.uint8))
         encoding.read_rle_bit_packed_hybrid(i, 1, length=None, o=o)
         out = o.so_far()[:len(data)]
         assert (out == ~data.isnull()).sum()
@@ -240,7 +240,7 @@ def test_make_definitions_without_nulls():
         out = np.empty(10000, dtype=np.int32)
         o = encoding.Numpy32(out)
         data = pd.Series([True] * np.random.randint(1, 10000))
-        out = writer.make_definitions(data)
+        out, d2 = writer.make_definitions(data)
 
         l = len(data) << 1
         p = 1
@@ -249,7 +249,7 @@ def test_make_definitions_without_nulls():
             p += 1
         assert len(out) == 4 + p + 1  # "length", num_count, value
 
-        i = encoding.Numpy8(np.frombuffer(out, dtype=np.uint8))
+        i = encoding.Numpy8(np.fromstring(out, dtype=np.uint8))
         encoding.read_rle_bit_packed_hybrid(i, 1, length=None, o=o)
         out = o.so_far()
         assert (out == ~data.isnull()).sum()

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -93,16 +93,17 @@ def find_type(data, convert=False):
         if convert:
             out = data.values
     elif dtype == "O":
-        if all(isinstance(i, str) for i in data[:10]):
+        head = data[:10] if isinstance(data, pd.Index) else data.valid()[:10]
+        if all(isinstance(i, str) for i in head):
             type, converted_type, width = (parquet_thrift.Type.BYTE_ARRAY,
                                            parquet_thrift.ConvertedType.UTF8, None)
             if convert:
                 out = data.str.encode('utf8').values
-        elif all(isinstance(i, bytes) for i in data[:10]):
+        elif all(isinstance(i, bytes) for i in head):
             type, converted_type, width = parquet_thrift.Type.BYTE_ARRAY, None, None
             if convert:
                 out = data.values
-        elif all(isinstance(i, list) for i in data[:10]) or all(isinstance(i, dict) for i in data[:10]):
+        elif all(isinstance(i, [list, dict]) for i in head):
             type, converted_type, width = (parquet_thrift.Type.BYTE_ARRAY,
                                            parquet_thrift.ConvertedType.JSON, None)
             if convert:
@@ -244,7 +245,11 @@ def write_length(l, o):
 def encode_rle_bp(data, width, o, withlength=False):
     """Write data into o using RLE/bitpacked hybrid
 
-    Uses bitpacking alone for now
+    data : values to encode (int32)
+    width : bits-per-value, set by max(data)
+    o : output encoding.Numpy8
+    withlength : bool
+        If definitions/repetitions, length of data must be pre-written
     """
     if withlength:
         start = o.loc
@@ -278,6 +283,30 @@ encode = {
 }
 
 
+def make_definitions(data):
+    """For data that can contain NULLs, produce definition levels binary
+    data: either bitpacked bools, or (if number of nulls == 0), single RLE
+    block."""
+    valid = ~data.isnull()
+    temp = encoding.Numpy8(np.empty(10, dtype=np.uint8))
+
+    if valid.all():
+        # no nulls at all
+        l = len(valid)
+        encode_unsigned_varint(l << 1, temp)
+        temp.write_byte(1)
+        block = struct.pack('<i', temp.loc) + temp.so_far().tostring()
+    else:
+        # bitpack bools
+        out = encode_plain(valid, None)
+
+        encode_unsigned_varint(len(out) << 1 | 1, temp)
+        head = temp.so_far().tostring()
+
+        block = struct.pack('<i', len(head + out)) + head + out
+    return block, data.valid()
+
+
 def write_column(f, data, selement, encoding='PLAIN', compression=None):
     """
     If f is a filename, opens data-only file to write to
@@ -298,9 +327,14 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
     compression: str or None
         if not None, must be one of the keys in ``compression.compress``
     """
+    has_nulls = selement.FieldRepetitionType = parquet_thrift.FieldRepetitionType.OPTIONAL
+    tot_rows = len(data)
 
     # no NULL handling (but NaNs, NaTs are allowed)
-    definition_data = b""
+    if has_nulls:
+        definition_data, data = make_definitions(data)
+    else:
+        definition_data = b""
 
     # No nested field handling (encode those as J/BSON)
     repetition_data = b""
@@ -335,7 +369,7 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
         encoding = "PLAIN_DICTIONARY"
 
     start = f.tell()
-    bdata = encode[encoding](data, selement)
+    bdata = definition_data + repetition_data + encode[encoding](data, selement)
     try:
         max, min = data.max(), data.min()
         if encoding == "DELTA_BINARY_PACKED":
@@ -348,7 +382,7 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
         max, min = None, None
 
     dph = parquet_thrift.DataPageHeader(
-            num_values=rows,
+            num_values=tot_rows,
             encoding=getattr(parquet_thrift.Encoding, encoding),
             definition_level_encoding=parquet_thrift.Encoding.RLE,
             repetition_level_encoding=parquet_thrift.Encoding.BIT_PACKED)
@@ -385,7 +419,7 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
                        parquet_thrift.Encoding.BIT_PACKED,
                        parquet_thrift.Encoding.PLAIN],
             codec=getattr(parquet_thrift.CompressionCodec, compression) if compression else 0,
-            num_values=rows, statistics=s,
+            num_values=tot_rows, statistics=s,
             data_page_offset=start, encoding_stats=p,
             key_value_metadata=[],
             total_uncompressed_size=uncompressed_size,
@@ -434,7 +468,7 @@ def make_part_file(f, data, schema, compression=None, encoding='PLAIN'):
     return rg
 
 
-def make_metadata(data):
+def make_metadata(data, has_nulls=[]):
     root = parquet_thrift.SchemaElement(name='schema',
                                         num_children=0)
     fmd = parquet_thrift.FileMetaData(num_rows=len(data),
@@ -449,6 +483,8 @@ def make_metadata(data):
             se.name = column
         else:
             se, type, _ = find_type(data[column])
+        if column in has_nulls and str(data[column].dtype) in ['category', 'object']:
+            se.repetition_type = parquet_thrift.FieldRepetitionType.OPTIONAL
         fmd.schema.append(se)
         root.num_children += 1
     return fmd
@@ -456,7 +492,7 @@ def make_metadata(data):
 
 def write(filename, data, partitions=[0], encoding="PLAIN",
           compression=None, file_scheme='simple', open_with=default_openw,
-          mkdirs=default_mkdirs):
+          mkdirs=default_mkdirs, has_nulls=[]):
     """ data is a 1d int array for starters
 
     Provisional parameters
@@ -464,9 +500,7 @@ def write(filename, data, partitions=[0], encoding="PLAIN",
     filename: string
         File contains everything (if file_scheme='same'), else contains the
         metadata only
-    data: pandas-like dataframe
-        simply could be dict of numpy arrays (in which case not sure if
-        partitions should be allowed)
+    data: pandas dataframe
     partitions: list of row index values to start new row groups
     encoding: single value from parquet_thrift.Encoding, if applied to all
         columns, or dict of name:parquet_thrift.Encoding for a different
@@ -477,6 +511,10 @@ def write(filename, data, partitions=[0], encoding="PLAIN",
         only the metadata
     open_with: function
         When called with a path/URL, returns an open file-like object
+    has_nulls: list of strings
+        The named columns can have nulls. Only applies to Object and Category
+        columns, as pandas ints can't have NULLs, and NaN/NaT is equivalent
+        to NULL in float and time-like columns.
     """
     sep = sep_from_open(open_with)
     if file_scheme == 'simple':
@@ -486,7 +524,7 @@ def write(filename, data, partitions=[0], encoding="PLAIN",
         fn = sep.join([filename, '_metadata'])
     with open_with(fn) as f:
         f.write(MARKER)
-        fmd = make_metadata(data)
+        fmd = make_metadata(data, has_nulls=has_nulls)
 
         for i, start in enumerate(partitions):
             end = partitions[i+1] if i < (len(partitions) - 1) else None
@@ -516,18 +554,16 @@ def write(filename, data, partitions=[0], encoding="PLAIN",
 
 def write_common_metadata(fn, fmd, open_with=default_openw):
     """For hive-style parquet, write schema in special shared file"""
-    try:
-        if isinstance(fn, str):
-            f = open_with(fn)
-        else:
-            f = fn
-        f.write(MARKER)
-        fmd.row_groups = []
-        foot_size = write_thrift(f, fmd)
-        f.write(struct.pack(b"<i", foot_size))
-        f.write(MARKER)
-    finally:
-        fn.close()
+    if isinstance(fn, str):
+        f = open_with(fn)
+    else:
+        f = fn
+    f.write(MARKER)
+    fmd.row_groups = []
+    foot_size = write_thrift(f, fmd)
+    f.write(struct.pack(b"<i", foot_size))
+    f.write(MARKER)
+    f.close()
 
 
 def dask_dataframe_to_parquet(filename, data,

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -103,7 +103,7 @@ def find_type(data, convert=False):
             type, converted_type, width = parquet_thrift.Type.BYTE_ARRAY, None, None
             if convert:
                 out = data.values
-        elif all(isinstance(i, [list, dict]) for i in head):
+        elif all(isinstance(i, (list, dict)) for i in head):
             type, converted_type, width = (parquet_thrift.Type.BYTE_ARRAY,
                                            parquet_thrift.ConvertedType.JSON, None)
             if convert:
@@ -327,11 +327,12 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
     compression: str or None
         if not None, must be one of the keys in ``compression.compress``
     """
-    has_nulls = selement.FieldRepetitionType = parquet_thrift.FieldRepetitionType.OPTIONAL
+    has_nulls = selement.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     tot_rows = len(data)
 
     # no NULL handling (but NaNs, NaTs are allowed)
     if has_nulls:
+        print('has nulls!')
         definition_data, data = make_definitions(data)
     else:
         definition_data = b""

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -430,6 +430,7 @@ def make_part_file(f, data, schema, compression=None, encoding='PLAIN'):
     foot_size = write_thrift(f, fmd)
     f.write(struct.pack(b"<i", foot_size))
     f.write(MARKER)
+    f.close()
     return rg
 
 
@@ -513,14 +514,20 @@ def write(filename, data, partitions=[0], encoding="PLAIN",
                               open_with)
 
 
-def write_common_metadata(fn, fmd, open_with):
+def write_common_metadata(fn, fmd, open_with=default_openw):
     """For hive-style parquet, write schema in special shared file"""
-    with open_with(fn) as f:
+    try:
+        if isinstance(fn, str):
+            f = open_with(fn)
+        else:
+            f = fn
         f.write(MARKER)
         fmd.row_groups = []
         foot_size = write_thrift(f, fmd)
         f.write(struct.pack(b"<i", foot_size))
         f.write(MARKER)
+    finally:
+        fn.close()
 
 
 def dask_dataframe_to_parquet(filename, data,


### PR DESCRIPTION
For the time being, can encode NULLs only for object/cat columns, and only if explicitly requested by passing `has_nulls=['mycol'...]` to `writer`. 

Will add to dask writer too before mergins.