### PR TITLE
Testing 'np.random.default_rng()'.

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -969,7 +969,7 @@ def test_multi_cat_split(tempdir):
 
 
 def test_multi(tempdir):
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(4)
     fn = os.path.join(tempdir, 'test.parq')
     N = 200
     df = pd.DataFrame(

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -969,11 +969,12 @@ def test_multi_cat_split(tempdir):
 
 
 def test_multi(tempdir):
+    rng = np.random.default_rng()
     fn = os.path.join(tempdir, 'test.parq')
     N = 200
     df = pd.DataFrame(
-        {'a': np.random.randint(10, size=N),
-         'b': np.random.choice(['a', 'b', 'c'], size=N),
+        {'a': rng.randint(10, size=N),
+         'b': rng.choice(['a', 'b', 'c'], size=N),
          'c': np.arange(200)})
     df = df.set_index(['a', 'b'])
     write(fn, df)

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -973,7 +973,7 @@ def test_multi(tempdir):
     fn = os.path.join(tempdir, 'test.parq')
     N = 200
     df = pd.DataFrame(
-        {'a': rng.randint(10, size=N),
+        {'a': rng.integers(10, size=N),
          'b': rng.choice(['a', 'b', 'c'], size=N),
          'c': np.arange(200)})
     df = df.set_index(['a', 'b'])

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -4,6 +4,7 @@ import struct
 import numpy as np
 import os
 import os.path
+import shutil
 import operator
 import pandas as pd
 import re

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -4,7 +4,6 @@ import struct
 import numpy as np
 import os
 import os.path
-import shutil
 import operator
 import pandas as pd
 import re


### PR DESCRIPTION
Honestly not knowing why it solves the failing config, but PR https://github.com/dask/fastparquet/pull/708 for this very same branch has shown it solves it.